### PR TITLE
fix: push with PAT after default checkout

### DIFF
--- a/.github/workflows/update_versions.yml
+++ b/.github/workflows/update_versions.yml
@@ -78,15 +78,16 @@ jobs:
       - name: Commit changes
         id: commit
         run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
           git add default.env
           if git diff --quiet && git diff --staged --quiet; then
             echo "No changes to commit. No new release needed."
             echo "changes_made=false" >> $GITHUB_OUTPUT
           else
             git commit -m "[CONF] Update OLLAMA_VERSION and OPEN_WEBUI_VERSION"
-            git push
+            git remote set-url origin https://x-access-token:${{ secrets.PAT }}@github.com/${{ github.repository }}.git
+            git push origin HEAD:${{ github.ref }}
             echo "Changes committed and pushed. Preparing for release."
             echo "changes_made=true" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
## Summary
- default checkout so fetch uses GitHub token
- push with personal token to attribute commits to actor

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68b85b54fcb48333bb1c168a8507eab6